### PR TITLE
Fix CMakeLists to properly configure mutils-containersConfig.cmake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@
 *.exe
 *.out
 *.app
+
+# Build directories
+build/
+build-*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,14 @@
-cmake_minimum_required (VERSION 3.1)
+cmake_minimum_required (VERSION 3.15)
 project (mutils-containers)
+include(GNUInstallDirs)
 
 #Versions
 set(mutils_containers_VERSION 1.0)
 
 #CXX FLAGS
-set(CMAKE_CXX_FLAGS_RELEASE "-std=c++14 -fPIC")
-set(CMAKE_CXX_FLAGS_DEBUG "-std=c++14 -fPIC -g")
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g")
 set(CMAKE_SHARED_LINKER_FLAGS "-shared --enable-new-dtags")
 
 if ( NOT DEFINED CMAKE_INSTALL_LIBDIR )
@@ -14,10 +16,7 @@ if ( NOT DEFINED CMAKE_INSTALL_LIBDIR )
 endif ( )
 
 #Test dependencies
-find_package(mutils 1.0)
-if(NOT ${mutils_FOUND})
-  message( FATAL_ERROR "mutils not found.")
-endif(NOT ${mutils_FOUND})
+find_package(mutils 1.0 REQUIRED)
 
 add_library(mutils-containers INTERFACE)
 
@@ -26,38 +25,38 @@ include_directories(${mutils-containers_SOURCE_DIR}/include)
 add_executable(test_buffer_generator test_buffer_generator.cpp)
 add_executable(test_multitype_map test_multitype_map.cpp)
 add_executable(test_type_map test_type_map.cpp)
-target_link_libraries(test_multitype_map ${mutils_LIBRARIES})
+target_link_libraries(test_multitype_map mutils::mutils)
 
 #Make install
+install(TARGETS mutils-containers
+        EXPORT mutils-containersTargets
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(DIRECTORY include/mutils-containers
-  DESTINATION include)
-install(TARGETS mutils-containers EXPORT mutils-containers
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        DESTINATION include)
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/mutils-containers/mutils-containersConfigVersion.cmake"
-  VERSION ${mutils_containers_VERSION}
-  COMPATIBILITY AnyNewerVersion
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/mutils-containersConfigVersion.cmake"
+    VERSION ${mutils_containers_VERSION}
+    COMPATIBILITY AnyNewerVersion
 )
 
-export(EXPORT mutils-containers
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/mutils-containers/mutils-containersTargets.cmake"
+set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/mutils-containers)
+configure_package_config_file(mutils-containersConfig.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/mutils-containersConfig.cmake"
+    INSTALL_DESTINATION ${ConfigPackageLocation}
+    PATH_VARS CMAKE_INSTALL_INCLUDEDIR
 )
 
-configure_file(mutils-containersConfig.cmake
-  "${CMAKE_CURRENT_BINARY_DIR}/mutils-containers/mutils-containersConfig.cmake"
-  COPYONLY
-)
-
-set(ConfigPackageLocation lib/cmake/mutils-containers)
-install(EXPORT mutils-containers
-  FILE mutils-containersTargets.cmake
-  DESTINATION ${ConfigPackageLocation}
+install(EXPORT mutils-containersTargets
+    FILE mutils-containersTargets.cmake
+    NAMESPACE mutils::
+    DESTINATION ${ConfigPackageLocation}
 )
 
 install(FILES
-  mutils-containersConfig.cmake
-  "${CMAKE_CURRENT_BINARY_DIR}/mutils-containers/mutils-containersConfigVersion.cmake"
-  DESTINATION ${ConfigPackageLocation}
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/mutils-containersConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/mutils-containersConfigVersion.cmake"
+    DESTINATION ${ConfigPackageLocation}
 )

--- a/mutils-containersConfig.cmake
+++ b/mutils-containersConfig.cmake
@@ -1,1 +1,6 @@
-set(mutils-containers_INCLUDE_DIRS "${CMAKE_INSTALL_PREFIX}/include")
+@PACKAGE_INIT@
+
+set_and_check(mutils-containers_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
+include("${CMAKE_CURRENT_LIST_DIR}/mutils-containersTargets.cmake")
+
+check_required_components(mutils-containers)


### PR DESCRIPTION
Using `${CMAKE_INSTALL_PREFIX}` in mutils-containersConfig.cmake doesn't work because that variable is not expanded when "make install" is executed, so the config file that gets installed still has the literal string `${CMAKE_INSTALL_PREFIX}` in it. Then when another CMake project uses `find_package(mutils-containers)`, it loads
mutils-containersConfig.cmake and replaces `${CMAKE_INSTALL_PREFIX}` with whatever its current value is for that project, even if it's not the directory where mutils-containers was installed.

This is the same bug fix described in mpmilano/mutils#4, just applied to mutils-containers. The CMakeLists incantations are almost exactly the same, except I used `${CMAKE_INSTALL_LIBDIR}` in the ConfigPackageLocation variable to make it more portable, following an example I found online.